### PR TITLE
bump elm-css version bounds

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,7 @@
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
-        "rtfeldman/elm-css": "15.1.0 <= v < 16.0.0"
+        "rtfeldman/elm-css": "15.1.0 <= v < 17.0.0"
     },
     "test-dependencies": {}
 }


### PR DESCRIPTION
Hey there!

Had some issues installing `elm-loading` in a project that depended on `elm-css` 16.0.0, so I went ahead and tried loosening the version bounds.... everything seems to work!

Not sure if best practice would be to increase the lower bound as well, i.e. `"16.0.0 <= v < 17.0.0"` or something.... I just vendor'd the source into my project, so I'm good for now. Thought the very least I could do was draw your attention do it.

Thanks so much for the nice package!